### PR TITLE
Remove 'common' from path in the minimal image

### DIFF
--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -15,7 +15,7 @@ RUN ipython profile create
 
 # Workaround for issue with ADD permissions
 USER root
-ADD common/profile_default /home/jovyan/.ipython/profile_default
+ADD profile_default /home/jovyan/.ipython/profile_default
 
 # Fake Google Analytics directory (for now)
 ADD ga/ /srv/ga/


### PR DESCRIPTION
The Dockerfile for the minimal image is already in `common/`, so we don't need that part of the path. Follow on PR for #17.