### PR TITLE
Bring custom.js, custom.css over from profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN echo "library(devtools); install_github('armstrtw/rzmq'); install_github('ta
 # Workaround for issue with ADD permissions
 USER root
 ADD common/profile_default /home/jovyan/.ipython/profile_default
+RUN cp /home/jovyan/.ipython/profile_default/static/custom/* /srv/ipython/IPython/html/static/custom/ && chmod a+r /srv/ipython/IPython/html/static/custom/
 
 # All the additions to give to the created user.
 ADD kernels/Julia/ /srv/Julia/


### PR DESCRIPTION
With how our nginx static file handling works, the custom.js wasn't being picked up. This moves it into the main IPython source tree that the rest of the static files are coming out of.