### PR TITLE
Add a header button for current sponsor, Rackspace

### DIFF
--- a/common/templates/page.html
+++ b/common/templates/page.html
@@ -12,3 +12,9 @@
 
 </script>
 {% endblock %}
+
+{% block header_buttons %}
+  <span id="login_widget">
+    <a class="pull-right" style="text-decoration: none; color:black;" href="https://developer.rackspace.com/"><span style="margin-left: 5px; margin-right: 5px;">on</span><img src="http://caa48e96f11ddd896e56-cbd62a0ad7e2d388825529106f960d1e.r78.cf2.rackcdn.com/RackspaceLogoManagedCloudLogo400w.jpg" height='32px'/></a>
+  </span>
+{% endblock %}

--- a/common/templates/page.html
+++ b/common/templates/page.html
@@ -15,6 +15,6 @@
 
 {% block header_buttons %}
   <span id="login_widget">
-    <a class="pull-right" style="text-decoration: none; color:black;" href="https://developer.rackspace.com/"><span style="margin-left: 5px; margin-right: 5px;">{% if notebook_name %}on{% else %}hosted by{% endif %}</span><img src="http://ddf912383141a8d7bbe4-e053e711fc85de3290f121ef0f0e3a1f.r87.cf1.rackcdn.com/fanatiguy-logo.png" height='24px'/></a>
+    <a class="pull-right" style="text-decoration: none; color:black; vertical-align:middle;" href="https://developer.rackspace.com/"><span style="margin-left: 5px; margin-right: 5px; vertical-align:middle;">{% if notebook_name %}on{% else %}hosted by Rackspace{% endif %}</span><img src="http://ddf912383141a8d7bbe4-e053e711fc85de3290f121ef0f0e3a1f.r87.cf1.rackcdn.com/fanatiguy-logo.png" height='24px' style="vertical-align:middle;"/></a>
   </span>
 {% endblock %}

--- a/common/templates/page.html
+++ b/common/templates/page.html
@@ -15,6 +15,6 @@
 
 {% block header_buttons %}
   <span id="login_widget">
-    <a class="pull-right" style="text-decoration: none; color:black;" href="https://developer.rackspace.com/"><span style="margin-left: 5px; margin-right: 5px;">on</span><img src="http://caa48e96f11ddd896e56-cbd62a0ad7e2d388825529106f960d1e.r78.cf2.rackcdn.com/RackspaceLogoManagedCloudLogo400w.jpg" height='32px'/></a>
+    <a class="pull-right" style="text-decoration: none; color:black;" href="https://developer.rackspace.com/"><span style="margin-left: 5px; margin-right: 5px;">on</span><img src="https://eafdbc63c97ce6bec9ef-b0a668e5876bef6fe25684caf71db405.ssl.cf1.rackcdn.com/v1-latest/logo-rackspace.png" height='28px'/></a>
   </span>
 {% endblock %}

--- a/common/templates/page.html
+++ b/common/templates/page.html
@@ -15,6 +15,6 @@
 
 {% block header_buttons %}
   <span id="login_widget">
-    <a class="pull-right" style="text-decoration: none; color:black; vertical-align:middle;" href="https://developer.rackspace.com/"><span style="margin-left: 5px; margin-right: 5px; vertical-align:middle;">{% if notebook_name %}on{% else %}hosted by Rackspace{% endif %}</span><img src="http://ddf912383141a8d7bbe4-e053e711fc85de3290f121ef0f0e3a1f.r87.cf1.rackcdn.com/fanatiguy-logo.png" height='24px' style="vertical-align:middle;"/></a>
+    <a class="pull-right" style="text-decoration: none; color:black; vertical-align:middle;" href="https://developer.rackspace.com/"><span style="margin-left: 5px; margin-right: 5px; vertical-align:middle;">{% if notebook_name %}on{% else %}Hosted by Rackspace{% endif %}</span><img src="http://ddf912383141a8d7bbe4-e053e711fc85de3290f121ef0f0e3a1f.r87.cf1.rackcdn.com/fanatiguy-logo.png" height='24px' style="vertical-align:middle;"/></a>
   </span>
 {% endblock %}

--- a/common/templates/page.html
+++ b/common/templates/page.html
@@ -15,6 +15,6 @@
 
 {% block header_buttons %}
   <span id="login_widget">
-    <a class="pull-right" style="text-decoration: none; color:black;" href="https://developer.rackspace.com/"><span style="margin-left: 5px; margin-right: 5px;">on</span><img src="https://eafdbc63c97ce6bec9ef-b0a668e5876bef6fe25684caf71db405.ssl.cf1.rackcdn.com/v1-latest/logo-rackspace.png" height='28px'/></a>
+    <a class="pull-right" style="text-decoration: none; color:black;" href="https://developer.rackspace.com/"><span style="margin-left: 5px; margin-right: 5px;">{% if notebook_name %}on{% else %}hosted by{% endif %}</span><img src="http://ddf912383141a8d7bbe4-e053e711fc85de3290f121ef0f0e3a1f.r87.cf1.rackcdn.com/fanatiguy-logo.png" height='24px'/></a>
   </span>
 {% endblock %}


### PR DESCRIPTION
This is an attempt for #24, to add a Rackspace logo to the current demo setup.

Current Prototype:

![screenshot 2015-05-07 22 43 09](https://cloud.githubusercontent.com/assets/836375/7530240/7e4cc55c-f50a-11e4-967e-7a98003d78b5.png)

![screenshot 2015-05-07 22 45 14](https://cloud.githubusercontent.com/assets/836375/7530251/adc1d7e6-f50a-11e4-894e-ac20c3c298bb.png)

/cc @fperez @ellisonbg 