### PR TITLE
Rely on Jupyter CDN, install libsm6

### DIFF
--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install -y git vim wget build-essential python-dev ca-certificates bzip2 && apt-get clean
+RUN apt-get update && apt-get install -y git vim wget build-essential python-dev ca-certificates bzip2 libsm6 && apt-get clean
 
 ENV CONDA_DIR /opt/conda
 

--- a/common/profile_default/ipython_notebook_config.py
+++ b/common/profile_default/ipython_notebook_config.py
@@ -22,5 +22,5 @@ c.NotebookApp.tornado_settings = {
     'headers': {
         'Content-Security-Policy': "frame-ancestors 'self' https://*.jupyter.org https://jupyter.github.io https://*.tmpnb.org"
     },
-    'static_url_prefix': 'https://cdn.jupyter.org/notebook/3.1.0/'
+    'static_url_prefix': 'https://cdn.jupyter.org/notebook/try/'
 }

--- a/common/profile_default/ipython_notebook_config.py
+++ b/common/profile_default/ipython_notebook_config.py
@@ -21,5 +21,6 @@ c.NotebookApp.extra_template_paths = ['/srv/templates/']
 c.NotebookApp.tornado_settings = {
     'headers': {
         'Content-Security-Policy': "frame-ancestors 'self' https://*.jupyter.org https://jupyter.github.io https://*.tmpnb.org"
-    }
+    },
+    'static_url_prefix': 'https://cdn.jupyter.org/notebook/3.1.0/'
 }


### PR DESCRIPTION
libsm6 is a system dependency that conda won't provide (needed for some plotting), since it's an X11 library.

This also sets up the `jupyter/minimal` and `jupyter/demo` images to use the Jupyter CDN. This does mean that custom.js is *not* loaded from the container though. We can modify the template but perhaps this needs to be addressed in the notebook.