### PR TITLE
Enable Spark 1.4.0 local mode for Python 3 and Scala

### DIFF
--- a/resources/kernel.json
+++ b/resources/kernel.json
@@ -1,0 +1,10 @@
+{
+    "display_name": "Scala 2.10.4 (Spark 1.4.0)",
+    "language": "scala",
+    "argv": [
+        "/opt/sparkkernel/bin/sparkkernel",
+        "--profile",
+        "{connection_file}"
+    ],
+    "codemirror_mode": "scala"
+}


### PR DESCRIPTION
* Build Scala kernel against Spark 1.4.0
* Install Scala kernel spec
* Configure Python3 paths for pyspark 1.4.0

Address issue #41 (and more).