### PR TITLE
Fix 'E: Unable to fetch some archives'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
 USER root
 
+RUN apt-get update
+
 # Julia dependencies
 RUN apt-get install -y julia libnettle4 && apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,8 @@ MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
 USER root
 
-RUN apt-get update
-
 # Julia dependencies
-RUN apt-get install -y julia libnettle4 && apt-get clean
+RUN apt-get update && apt-get install -y julia libnettle4 && apt-get clean
 
 # R dependencies that conda can't provide (X, fonts, compilers)
 RUN apt-get install -y libxrender1 fonts-dejavu gfortran gcc && apt-get clean


### PR DESCRIPTION
I ran into the following issue trying to run docker build:

```
...
...
Get:23 http://httpredir.debian.org/debian/ jessie/main python3-gi amd64 3.14.0-1 [454 kB]
Fetched 10.8 MB in 13s (776 kB/s)
E: Failed to fetch http://httpredir.debian.org/debian/pool/main/a/apt/libapt-inst1.5_1.0.9.8_amd64.deb  404  Not Found [IP: 46.43.34.31 80]

E: Failed to fetch http://httpredir.debian.org/debian/pool/main/d/dbus/libdbus-1-3_1.8.18-0+deb8u1_amd64.deb  404  Not Found [IP: 46.43.34.31 80]

E: Failed to fetch http://httpredir.debian.org/debian/pool/main/a/apt/apt-utils_1.0.9.8_amd64.deb  404  Not Found [IP: 46.43.34.31 80]

E: Failed to fetch http://httpredir.debian.org/debian/pool/main/p/python-apt/python3-apt_0.9.3.11_amd64.deb  404  Not Found [IP: 5.10.144.130 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The command '/bin/sh -c apt-get install -y --no-install-recommends software-properties-common && apt-get clean' returned a non-zero code: 100
```