### PR TITLE
Add stackage to IHaskell build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,10 +94,11 @@ RUN julia -e 'Pkg.add("Gadfly")' && julia -e 'Pkg.add("RDatasets")'
 
 # IHaskell + IHaskell-Widgets + Dependencies for examples
 RUN cabal update && \
+    curl 'https://www.stackage.org/lts-2.22/cabal.config?global=true' >> ~/.cabal/config && \
     cabal install cpphs && \
     cabal install gtk2hs-buildtools && \
     cabal install ihaskell-0.8.0.0 --reorder-goals && \
-    cabal install singletons-1.1.2.1 ihaskell-widgets-0.2.0.0 HTTP Chart Chart-cairo && \
+    cabal install ihaskell-widgets-0.2.0.0 HTTP Chart Chart-cairo && \
     ihaskell install && \
     rm -fr $(echo ~/.cabal/bin/* | grep -iv ihaskell) ~/.cabal/packages ~/.cabal/share/doc ~/.cabal/setup-exe-cache ~/.cabal/logs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN julia -e 'Pkg.add("Gadfly")' && julia -e 'Pkg.add("RDatasets")'
 
 # IHaskell + IHaskell-Widgets + Dependencies for examples
 RUN cabal update && \
-    curl 'https://www.stackage.org/lts-2.22/cabal.config?global=true' >> ~/.cabal/config && \
+    CURL_CA_BUNDLE='/etc/ssl/certs/ca-certificates.crt' curl 'https://www.stackage.org/lts-2.22/cabal.config?global=true' >> ~/.cabal/config && \
     cabal install cpphs && \
     cabal install gtk2hs-buildtools && \
     cabal install ihaskell-0.8.0.0 --reorder-goals && \


### PR DESCRIPTION
Sets up the IHaskell build to use a fixed snapshot of package
versions, verified as working (currently being used in the IHaskell
master branch).

Using lts-2.22, which is the last snapshot built for GHC-7.8.4.