### PR TITLE
Welcome to Spark with Python notebook

### DIFF
--- a/notebooks/Welcome to Spark with Python.ipynb
+++ b/notebooks/Welcome to Spark with Python.ipynb
@@ -1,0 +1,579 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "![Spark Logo](http://spark-mooc.github.io/web-assets/images/ta_Spark-logo-small.png)\n",
+    "![Python Logo](http://spark-mooc.github.io/web-assets/images/python-logo-master-v3-TM-flattened_small.png)\n",
+    "\n",
+    "# Welcome to Apache Spark with Python\n",
+    "\n",
+    "> Apache Spark is a fast and general-purpose cluster computing system. It provides high-level APIs in Java, Scala, Python and R, and an optimized engine that supports general execution graphs. It also supports a rich set of higher-level tools including Spark SQL for SQL and structured data processing, MLlib for machine learning, GraphX for graph processing, and Spark Streaming. \n",
+    "- http://spark.apache.org/\n",
+    "\n",
+    "In this notebook, we'll train two classifiers to predict survivors in the [Titanic dataset](../edit/datasets/COUNT/titanic.csv). We'll use this classic machine learning problem as a brief introduction to using Apache Spark local mode in a notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import pyspark  \n",
+    "from pyspark.mllib.regression import LabeledPoint\n",
+    "from pyspark.mllib.classification import LogisticRegressionWithSGD\n",
+    "from pyspark.mllib.tree import DecisionTree"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First we create a [SparkContext](http://spark.apache.org/docs/latest/api/python/pyspark.html#pyspark.SparkContext), the main object in the Spark API. This call may take a few seconds to return as it fires up a JVM under the covers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "sc = pyspark.SparkContext()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sample the data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We point the context at a CSV file on disk. The result is a [RDD](http://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds), not the content of the file. This is a Spark [transformation](http://spark.apache.org/docs/latest/programming-guide.html#transformations)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "raw_rdd = sc.textFile(\"datasets/COUNT/titanic.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We query RDD for the number of lines in the file. The call here causes the file to be read and the result computed. This is a Spark [action](http://spark.apache.org/docs/latest/programming-guide.html#actions)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1317"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "raw_rdd.count()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We query for the first five rows of the RDD. Even though the data is small, we shouldn't get into the habit of pulling the entire dataset into the notebook. Many datasets that we might want to work with using Spark will be much too large to fit in memory of a single machine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['\"\",\"class\",\"age\",\"sex\",\"survived\"',\n",
+       " '\"1\",\"1st class\",\"adults\",\"man\",\"yes\"',\n",
+       " '\"2\",\"1st class\",\"adults\",\"man\",\"yes\"',\n",
+       " '\"3\",\"1st class\",\"adults\",\"man\",\"yes\"',\n",
+       " '\"4\",\"1st class\",\"adults\",\"man\",\"yes\"']"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "raw_rdd.take(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see a header row followed by a set of data rows. We filter out the header to define a new RDD containing only the data rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "header = raw_rdd.first()\n",
+    "data_rdd = raw_rdd.filter(lambda line: line != header)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We take a random sample of the data rows to better understand the possible values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['\"159\",\"1st class\",\"adults\",\"man\",\"no\"',\n",
+       " '\"256\",\"1st class\",\"adults\",\"women\",\"yes\"',\n",
+       " '\"1204\",\"3rd class\",\"adults\",\"women\",\"no\"',\n",
+       " '\"758\",\"3rd class\",\"adults\",\"man\",\"no\"',\n",
+       " '\"730\",\"3rd class\",\"adults\",\"man\",\"no\"']"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_rdd.takeSample(False, 5, 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that the first value in every row is a passenger number. The next three values are the passenger attributes we might use to predict passenger survival: ticket class, age group, and gender. The final value is the survival ground truth."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create labeled points (i.e., feature vectors and ground truth)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we define a function to turn the passenger attributions into structured `LabeledPoint` objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def row_to_labeled_point(line):\n",
+    "    '''\n",
+    "    Builds a LabelPoint consisting of:\n",
+    "    \n",
+    "    survival (truth): 0=no, 1=yes\n",
+    "    ticket class: 0=1st class, 1=2nd class, 2=3rd class\n",
+    "    age group: 0=child, 1=adults\n",
+    "    gender: 0=man, 1=woman\n",
+    "    '''\n",
+    "    passenger_id, klass, age, sex, survived = [segs.strip('\"') for segs in line.split(',')]\n",
+    "    klass = int(klass[0]) - 1\n",
+    "    \n",
+    "    if (age not in ['adults', 'child'] or \n",
+    "        sex not in ['man', 'women'] or\n",
+    "        survived not in ['yes', 'no']):\n",
+    "        raise RuntimeError('unknown value')\n",
+    "    \n",
+    "    features = [\n",
+    "        klass,\n",
+    "        (1 if age == 'adults' else 0),\n",
+    "        (1 if sex == 'women' else 0)\n",
+    "    ]\n",
+    "    return LabeledPoint(1 if survived == 'yes' else 0, features)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We apply the function to all rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "labeled_points_rdd = data_rdd.map(row_to_labeled_point)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We take a random sample of the resulting points to inspect them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[LabeledPoint(0.0, [0.0,1.0,0.0]),\n",
+       " LabeledPoint(1.0, [0.0,1.0,1.0]),\n",
+       " LabeledPoint(0.0, [2.0,1.0,1.0]),\n",
+       " LabeledPoint(0.0, [2.0,1.0,0.0]),\n",
+       " LabeledPoint(0.0, [2.0,1.0,0.0])]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "labeled_points_rdd.takeSample(False, 5, 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Split for training and test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We split the transformed data into a training (70%) and test set (30%), and print the total number of items in each segment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "training_rdd, test_rdd = labeled_points_rdd.randomSplit([0.7, 0.3], seed = 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "training_count = training_rdd.count()\n",
+    "test_count = test_rdd.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(914, 402)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "training_count, test_count"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train and test a decision tree classifier"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we train a [DecisionTree](http://spark.apache.org/docs/latest/api/python/pyspark.mllib.html#pyspark.mllib.tree.DecisionTree) model. We specify that we're training a boolean classifier (i.e., there are two outcomes). We also specify that all of our features are categorical and the number of possible categories for each."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "model = DecisionTree.trainClassifier(training_rdd, \n",
+    "                                     numClasses=2, \n",
+    "                                     categoricalFeaturesInfo={\n",
+    "                                        0: 3,\n",
+    "                                        1: 2,\n",
+    "                                        2: 2\n",
+    "                                     })"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now apply the trained model to the feature values in the test set to get the list of predicted outcomines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "predictions_rdd = model.predict(test_rdd.map(lambda x: x.features))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We bundle our predictions with the ground truth outcome for each passenger in the test set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "truth_and_predictions_rdd = test_rdd.map(lambda lp: lp.label).zip(predictions_rdd)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we compute the test error (% predicted survival outcomes == actual outcomes) and display the decision tree for good measure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy = 0.7985074626865671\n",
+      "DecisionTreeModel classifier of depth 4 with 21 nodes\n",
+      "  If (feature 2 in {0.0})\n",
+      "   If (feature 1 in {0.0})\n",
+      "    If (feature 0 in {2.0})\n",
+      "     Predict: 0.0\n",
+      "    Else (feature 0 not in {2.0})\n",
+      "     Predict: 1.0\n",
+      "   Else (feature 1 not in {0.0})\n",
+      "    If (feature 0 in {0.0})\n",
+      "     Predict: 0.0\n",
+      "    Else (feature 0 not in {0.0})\n",
+      "     If (feature 0 in {1.0})\n",
+      "      Predict: 0.0\n",
+      "     Else (feature 0 not in {1.0})\n",
+      "      Predict: 0.0\n",
+      "  Else (feature 2 not in {0.0})\n",
+      "   If (feature 0 in {2.0})\n",
+      "    If (feature 1 in {0.0})\n",
+      "     Predict: 0.0\n",
+      "    Else (feature 1 not in {0.0})\n",
+      "     Predict: 0.0\n",
+      "   Else (feature 0 not in {2.0})\n",
+      "    If (feature 0 in {0.0})\n",
+      "     If (feature 1 in {0.0})\n",
+      "      Predict: 1.0\n",
+      "     Else (feature 1 not in {0.0})\n",
+      "      Predict: 1.0\n",
+      "    Else (feature 0 not in {0.0})\n",
+      "     If (feature 1 in {0.0})\n",
+      "      Predict: 1.0\n",
+      "     Else (feature 1 not in {0.0})\n",
+      "      Predict: 1.0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "accuracy = truth_and_predictions_rdd.filter(lambda v_p: v_p[0] == v_p[1]).count() / float(test_count)\n",
+    "print('Accuracy =', accuracy)\n",
+    "print(model.toDebugString())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train and test a logistic regression classifier"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For a simple comparison, we also train and test a [LogisticRegressionWithSGD](http://spark.apache.org/docs/latest/api/python/pyspark.mllib.html#pyspark.mllib.classification.LogisticRegressionWithSGD) model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "model = LogisticRegressionWithSGD.train(training_rdd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "predictions_rdd = model.predict(test_rdd.map(lambda x: x.features))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "labels_and_predictions_rdd = test_rdd.map(lambda lp: lp.label).zip(predictions_rdd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy = 0.7860696517412935\n"
+     ]
+    }
+   ],
+   "source": [
+    "accuracy = labels_and_predictions_rdd.filter(lambda v_p: v_p[0] == v_p[1]).count() / float(test_count)\n",
+    "print('Accuracy =', accuracy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The two classifiers show similar accuracy. More information about the passengers could definitely help improve this metric."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Brief intro to Spark with Python in Jupyter. Uses the titanic datasets already in the docker-demo-image deployed on tmpnb.org. Loads the data, samples it, parses it into labeled points, trains a decision tree, and trains a log reg classifier.

Credit: Draft version of this notebook was by @djvita
