### PR TITLE
Fixed Markdown headers: Added space after `#`

### DIFF
--- a/notebooks/communities/pyladies/Python 101.ipynb
+++ b/notebooks/communities/pyladies/Python 101.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#Welcome to Python 101\n",
+    "# Welcome to Python 101\n",
     "\n",
     "<a href=\"http://pyladies.org\"><img align=\"right\" src=\"http://www.pyladies.com/assets/images/pylady_geek.png\" alt=\"Pyladies\" style=\"position:relative;top:-80px;right:30px;height:50px;\" /></a>\n",
     "\n",
@@ -20,7 +20,7 @@
     "      the [Hitchhiker's Guide to Python][python-guide].)\n",
     "\n",
     "\n",
-    "##Outline\n",
+    "## Outline\n",
     "\n",
     "- Operators and functions\n",
     "- Data and container types\n",
@@ -115,7 +115,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Challenge for you\n",
+    "## Challenge for you\n",
     "The arithmetic operators in Python are:\n",
     "```python\n",
     "    +   -   *   /   **   %   //\n",
@@ -142,7 +142,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##More math requires the math module"
+    "## More math requires the math module"
    ]
   },
   {
@@ -189,7 +189,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Challenge for you\n",
+    "## Challenge for you\n",
     "Hint: `help(math)` will show all the functions...\n",
     "\n",
     "- What is the arc cosine of `0.743144` in degrees?"
@@ -223,7 +223,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Math takeaways\n",
+    "## Math takeaways\n",
     "- Operators are what you think\n",
     "- Be careful of unintended integer math\n",
     "- the `math` module has the remaining functions"
@@ -233,7 +233,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#Strings\n",
+    "# Strings\n",
     "\n",
     "(Easier in Python than in any other language ever. Even Perl.)"
    ]
@@ -242,7 +242,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Strings\n",
+    "## Strings\n",
     "Use `help(str)` to see available functions for string objects. For help on a particular function from the class, type the class name and the function name: `help(str.join)`\n",
     "\n",
     "String operations are easy:\n",
@@ -312,7 +312,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Challenge for you\n",
+    "## Challenge for you\n",
     "Using only string addition (concatenation) and the function `str.join`, combine `declaration` and `sayings` :\n",
     "\n",
     "```python\n",
@@ -439,7 +439,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##String formatting\n",
+    "## String formatting\n",
     "There are a bunch of ways to do string formatting:\n",
     "- C-style:\n",
     "```python\n",
@@ -552,7 +552,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##String takeaways\n",
+    "## String takeaways\n",
     "- `str.split` and `str.join`, plus the **regex** module (pattern matching tools for strings), make Python my language of choice for data manipulation\n",
     "- There are many ways to format a string\n",
     "- `help(str)` for more"
@@ -562,7 +562,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#Quick look at other types"
+    "# Quick look at other types"
    ]
   },
   {
@@ -737,12 +737,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Caveat\n",
+    "## Caveat\n",
     "Lists, when copied, are copied by pointer. What that means is every symbol that points to a list, points to that same list.\n",
     "\n",
     "Same with dictionaries and sets.\n",
     "\n",
-    "###Example:\n",
+    "### Example:\n",
     "```python\n",
     "fifth_element = x[4]\n",
     "fifth_element.append(\"Both!\")\n",
@@ -786,7 +786,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###To make a duplicate copy you must do it explicitly\n",
+    "### To make a duplicate copy you must do it explicitly\n",
     "[The copy module ] [copy]\n",
     "\n",
     "Example:\n",
@@ -942,7 +942,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Common atomic types\n",
+    "## Common atomic types\n",
     "\n",
     "<table style=\"border:3px solid white;\"><tr>\n",
     "<td> boolean</td>\n",
@@ -958,7 +958,7 @@
     "<td><tt>None</tt></td>\n",
     "</tr></table>\n",
     "\n",
-    "##Common container types\n",
+    "## Common container types\n",
     "\n",
     "<table style=\"border:3px solid white;\"><tr>\n",
     "<td> list </td>\n",
@@ -989,13 +989,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###Iterable\n",
+    "### Iterable\n",
     "You can loop over it\n",
     "\n",
-    "###Mutable\n",
+    "### Mutable\n",
     "You can change it\n",
     "\n",
-    "###Hashable\n",
+    "### Hashable\n",
     "A hash function converts an object to a number that will always be the same for the object. They help with identifying the object. A better explanation kind of has to go into the guts of the code...\n"
    ]
   },
@@ -1003,14 +1003,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#Container examples"
+    "# Container examples"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##List\n",
+    "## List\n",
     "- To make a list, use square braces."
    ]
   },
@@ -1136,7 +1136,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Tuple\n",
+    "## Tuple\n",
     "To make a tuple, use parenthesis."
    ]
   },
@@ -1188,7 +1188,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Set\n",
+    "## Set\n",
     "To make a set, wrap a list with the function `set()`.\n",
     "- Items in a set are unique\n",
     "- Lists, dictionaries, and sets cannot be in a set"
@@ -1258,7 +1258,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Dictionary\n",
+    "## Dictionary\n",
     "To make a dictionary, use curly braces.\n",
     "- A dictionary is a set of key,value pairs where the keys\n",
     "  are unique.\n",
@@ -1375,7 +1375,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Type takeaways\n",
+    "## Type takeaways\n",
     "- Lists, tuples, dictionaries, sets all are base Python objects\n",
     "- Be careful of duck typing\n",
     "- Remember about copy / deepcopy\n",
@@ -1392,7 +1392,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Function definition and punctuation\n",
+    "## Function definition and punctuation\n",
     "\n",
     "The syntax for creating a function is:\n",
     "\n",
@@ -1456,7 +1456,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Whitespace matters\n",
+    "## Whitespace matters\n",
     "The 'tab' character **'\\t'** counts as one single character even if it looks like multiple characters in your editor.\n",
     "\n",
     "**But indentation is how you denote nesting!**\n",
@@ -1557,7 +1557,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Duck typing\n",
+    "## Duck typing\n",
     "Python's philosophy for handling data types is called **duck typing** (If it walks like a duck, and quacks like a duck, it's a duck). Functions do no type checking — they happily process an argument until something breaks. This is great for fast coding but can sometimes make for odd errors. (If you care to specify types, there is a [standard way to do it][pep484], but don't worry about this if you're a beginner.)\n",
     "\n",
     "[pep484]: https://www.python.org/dev/peps/pep-0484/"
@@ -1567,7 +1567,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Challenge for you\n",
+    "## Challenge for you\n",
     "Create another function named `greet_people` that takes a list of people and greets them all one by one. Hint: you can call the function `greet_person`."
    ]
   },
@@ -1640,7 +1640,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Quack quack\n",
+    "## Quack quack\n",
     "Make a list of all of the people in your group and use your function to greet them:\n",
     "\n",
     "```python\n",
@@ -1669,7 +1669,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##WTW?\n",
+    "## WTW?\n",
     "Remember strings are iterable...\n",
     "\n",
     "\n",
@@ -1681,7 +1681,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Whitespace / duck typing takeways\n",
+    "## Whitespace / duck typing takeways\n",
     "\n",
     "- Indentation is how to denote nesting in Python\n",
     "- Do not use tabs; expand them to spaces\n",
@@ -1692,9 +1692,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#Control structures\n",
+    "# Control structures\n",
     "\n",
-    "###Common comparison operators\n",
+    "### Common comparison operators\n",
     "<table style=\"border:3px solid white;\"><tr>\n",
     "<td><tt>==</tt></td>\n",
     "<td><tt>!=</tt></td>\n",
@@ -1719,7 +1719,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###If statement\n",
+    "### If statement\n",
     "\n",
     "The `if` statement checks whether the condition after `if` is true.\n",
     "Note the placement of colons (`:`) and the indentation. These are not optional.\n",
@@ -1790,7 +1790,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###While loop\n",
+    "### While loop\n",
     "\n",
     "The `while` loop requires you to set up something first. Then it\n",
     "tests whether the statement after the `while` is true. \n",
@@ -1833,7 +1833,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###For loop\n",
+    "### For loop\n",
     "\n",
     "The `for` loop iterates over the items after the `for`,\n",
     "executing the body of the loop once per item."
@@ -1898,7 +1898,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Challenge for you\n",
+    "## Challenge for you\n",
     "Please look at this code and think of what will happen, then copy it and run it. We introduce `break` and `continue`...can you tell what they do?\n",
     "\n",
     "- When will it stop?\n",
@@ -1932,7 +1932,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#You are done, welcome to Python!\n",
+    "# You are done, welcome to Python!\n",
     "\n",
     "## ... and you rock!"
    ]


### PR DESCRIPTION
The Headers were [not rendering correctly for me](https://goo.gl/photos/jXupjimdit53dQb3A). It seems like Jupyter's Markdown parser requires a space after the `#`, before the words, in the Header. Github's parser does not.

Maybe this is an issue with Jupyter's markdown, actually, also?