### PR TITLE
install rbczmq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get install -y --no-install-recommends ruby ruby-dev libtool autoconf au
     ln -s /usr/bin/libtoolize /usr/bin/libtool && \
     apt-get clean
 RUN gem update --system --no-document && \
-    gem install --no-document sciruby-full:0.2.10
+    gem install --no-document sciruby-full:0.2.10 rbczmq
 
 # Spark dependencies
 ENV APACHE_SPARK_VERSION 1.4.1


### PR DESCRIPTION
appears to be needed for iruby, which doesn't express this dependency

@minad it would appear that nothing in sciruby-full expresses a dependency on a zmq binding, so iruby doesn't start. What would you recommend as the canonical installation command for getting sciruby with the iruby kernel? I see that the iruby demo Dockerfile has the same lines, and also doesn't work in the same way.