### PR TITLE
bump docker-stacks tag to e7367

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,8 +141,8 @@ RUN find /home/jovyan/work -name '*.ipynb' -exec jupyter nbconvert --to notebook
 # can reuse the very expensive build of all the above with their own site 
 # customization.
 
-# Expose our custom setup to the installed ipython (for mounting by nginx)
-COPY resources/custom.js /opt/conda/lib/python3.4/site-packages/notebook/static/custom/
+# Install our custom.js
+COPY resources/custom.js /home/jovyan/.jupyter/custom/
 
 # Add the templates
 COPY resources/templates/ /srv/templates/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Docker demo image, as used on try.jupyter.org and tmpnb.org
 
-FROM jupyter/all-spark-notebook:a249876881d3
+FROM jupyter/all-spark-notebook:e736784a1a8f
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
@@ -28,7 +28,7 @@ RUN apt-get update && \
     libnettle4 && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-USER jovyan
+USER $NB_USER
 
 # R packages including IRKernel which gets installed globally.
 RUN conda config --add channels r && \
@@ -61,7 +61,7 @@ RUN julia -e 'Pkg.add("IJulia")' && \
 
 # Show Julia where conda libraries are
 # Add essential packages
-RUN echo 'push!(Sys.DL_LOAD_PATH, "/opt/conda/lib")' > /home/$NB_USER/.juliarc.jl && \
+RUN echo "push!(Sys.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" > /home/$NB_USER/.juliarc.jl && \
     julia -e 'Pkg.add("Gadfly")' && julia -e 'Pkg.add("RDatasets")' && julia -F -e 'Pkg.add("HDF5")'
 # ENDINCLUDE jupyter/datascience-notebook
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,8 +85,9 @@ RUN apt-get install -y --no-install-recommends zlib1g-dev libzmq3-dev libtinfo-d
 RUN apt-get install -y --no-install-recommends ruby ruby-dev libtool autoconf automake gnuplot-nox libsqlite3-dev libatlas-base-dev libgsl0-dev libmagick++-dev imagemagick && \
     ln -s /usr/bin/libtoolize /usr/bin/libtool && \
     apt-get clean
+# We need to pin activemodel to 4.2 while we have ruby < 2.2
 RUN gem update --system --no-document && \
-    gem install --no-document sciruby-full
+    gem install --no-document 'activemodel:~> 4.2' sciruby-full
 
 # Now switch to jovyan for all conda and other package manager installs
 USER jovyan

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build dev nuke super-nuke upload
 
-TAG ?= a249876881d3
+TAG ?= e736784a1a8f
 
 help:
 	@cat Makefile


### PR DESCRIPTION
Get scipy stack back in, which includes sympy.
The previous build inherited from all-spark before pyspark was re-based on scipy.

- [x] waiting for test build

closes jupyter/try.jupyter.org#13