### PR TITLE
Fix broken link in Welcome to Python.py

### DIFF
--- a/notebooks/Welcome to Python.ipynb
+++ b/notebooks/Welcome to Python.ipynb
@@ -1,1 +1,94 @@
-{"metadata": {"language_info": {"name": "python", "codemirror_mode": {"version": 3, "name": "ipython"}, "pygments_lexer": "ipython3", "mimetype": "text/x-python"}, "kernelspec": {"name": "python3", "display_name": "IPython (Python 3)"}, "signature": "sha256:202e20482dae220841103f90f99ce462955d0f629eee8f427ce2d6a6d767e4cb"}, "nbformat": 4, "nbformat_minor": 0, "cells": [{"source": "<div class=\"clearfix\" style=\"padding: 10px; padding-left: 0px\">\n<img src=\"https://raw.githubusercontent.com/jupyter/nature-demo/master/images/jupyter-logo.png\" width=\"150px\" style=\"display: inline-block; margin-top: 5px;\">\n<a href=\"http://bit.ly/tmpnbdevrax\"><img src=\"https://cloud.githubusercontent.com/assets/836375/4916141/2732892e-64d6-11e4-980f-11afcf03ca31.png\" width=\"150px\" class=\"pull-right\" style=\"display: inline-block; margin: 0px;\"></a>\n</div>\n\n## Welcome to the Temporary Notebook (tmpnb) service!\n\nThis Notebook Server was **launched just for you**. It's a temporary way for you to try out a recent development version of the IPython/Jupyter notebook.\n\n<div class=\"alert alert-warning\" role=\"alert\" style=\"margin: 10px\">\n<p>**WARNING**</p>\n\n<p>Don't rely on this server for anything you want to last - your server will be *deleted after 10 minutes of inactivity*.</p>\n</div>\n\nYour server is hosted thanks to [Rackspace](http://bit.ly/tmpnbdevrax), on their on-demand bare metal servers, [OnMetal](http://bit.ly/onmetal).\n", "metadata": {}, "cell_type": "markdown"}, {"source": "### Run some Python code!\n\nTo run the code below:\n\n1. Click on the cell to select it.\n2. Press `SHIFT+ENTER` on your keyboard or press the play button (<button class='fa fa-play icon-play btn btn-xs btn-default'></button>) in the toolbar above.\n\nA full tutorial for using the notebook interface is available [here](ipython_examples/Notebook/Index.ipynb).", "metadata": {}, "cell_type": "markdown"}, {"outputs": [], "metadata": {"collapsed": false, "trusted": true}, "cell_type": "code", "execution_count": null, "source": "%matplotlib notebook\n\nimport pandas as pd\nimport numpy as np\nimport matplotlib\n\nfrom matplotlib import pyplot as plt\nimport seaborn as sns\n\nts = pd.Series(np.random.randn(1000), index=pd.date_range('1/1/2000', periods=1000))\nts = ts.cumsum()\n\ndf = pd.DataFrame(np.random.randn(1000, 4), index=ts.index,\n                  columns=['A', 'B', 'C', 'D'])\ndf = df.cumsum()\ndf.plot(); plt.legend(loc='best')"}, {"source": "Feel free to open new cells using the plus button (<button class='fa fa-plus icon-plus btn btn-xs btn-default'></button>), or hitting shift-enter while this cell is selected.\n\nBehind the scenes, the software that powers this is [tmpnb](https://github.com/jupyter/tmpnb), a  Tornado application that spawns [pre-built Docker containers](https://github.com/ipython/docker-notebook) and then uses the [jupyter/configurable-http-proxy](https://github.com/jupyter/configurable-http-proxy) to put your notebook server on a unique path.", "metadata": {}, "cell_type": "markdown"}]}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"clearfix\" style=\"padding: 10px; padding-left: 0px\">\n",
+    "<img src=\"https://raw.githubusercontent.com/jupyter/nature-demo/master/images/jupyter-logo.png\" width=\"150px\" style=\"display: inline-block; margin-top: 5px;\">\n",
+    "<a href=\"http://bit.ly/tmpnbdevrax\"><img src=\"https://cloud.githubusercontent.com/assets/836375/4916141/2732892e-64d6-11e4-980f-11afcf03ca31.png\" width=\"150px\" class=\"pull-right\" style=\"display: inline-block; margin: 0px;\"></a>\n",
+    "</div>\n",
+    "\n",
+    "## Welcome to the Temporary Notebook (tmpnb) service!\n",
+    "\n",
+    "This Notebook Server was **launched just for you**. It's a temporary way for you to try out a recent development version of the IPython/Jupyter notebook.\n",
+    "\n",
+    "<div class=\"alert alert-warning\" role=\"alert\" style=\"margin: 10px\">\n",
+    "<p>**WARNING**</p>\n",
+    "\n",
+    "<p>Don't rely on this server for anything you want to last - your server will be *deleted after 10 minutes of inactivity*.</p>\n",
+    "</div>\n",
+    "\n",
+    "Your server is hosted thanks to [Rackspace](http://bit.ly/tmpnbdevrax), on their on-demand bare metal servers, [OnMetal](http://bit.ly/onmetal).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run some Python code!\n",
+    "\n",
+    "To run the code below:\n",
+    "\n",
+    "1. Click on the cell to select it.\n",
+    "2. Press `SHIFT+ENTER` on your keyboard or press the play button (<button class='fa fa-play icon-play btn btn-xs btn-default'></button>) in the toolbar above.\n",
+    "\n",
+    "A full tutorial for using the notebook interface is available [here](https://nbviewer.jupyter.org/github/ipython/ipython/blob/2.x/examples/Notebook/Index.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib notebook\n",
+    "\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib\n",
+    "\n",
+    "from matplotlib import pyplot as plt\n",
+    "import seaborn as sns\n",
+    "\n",
+    "ts = pd.Series(np.random.randn(1000), index=pd.date_range('1/1/2000', periods=1000))\n",
+    "ts = ts.cumsum()\n",
+    "\n",
+    "df = pd.DataFrame(np.random.randn(1000, 4), index=ts.index,\n",
+    "                  columns=['A', 'B', 'C', 'D'])\n",
+    "df = df.cumsum()\n",
+    "df.plot(); plt.legend(loc='best')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Feel free to open new cells using the plus button (<button class='fa fa-plus icon-plus btn btn-xs btn-default'></button>), or hitting shift-enter while this cell is selected.\n",
+    "\n",
+    "Behind the scenes, the software that powers this is [tmpnb](https://github.com/jupyter/tmpnb), a  Tornado application that spawns [pre-built Docker containers](https://github.com/ipython/docker-notebook) and then uses the [jupyter/configurable-http-proxy](https://github.com/jupyter/configurable-http-proxy) to put your notebook server on a unique path."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
I'm guessing the link is supposed to be https://nbviewer.jupyter.org/github/ipython/ipython/blob/2.x/examples/Notebook/Index.ipynb, but I may be wrong

Fixes #102 
Fixes jupyter/help#276